### PR TITLE
Gui fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,13 +113,17 @@
     <script>
         // JavaScript Code that resizes background image responsively
         var zoom = Math.round(window.devicePixelRatio * 100);
+        //background for mobile
+        function mobileSize(){document.getElementsByTagName('body')[0].style.backgroundSize = "1800px auto";}
         function bgResize(){
             if (zoom < 130){
             var factor = 130/zoom;
             var vh = Math.max(document.documentElement.clientHeight || 0, window.innerHeight, 750);
             var transform = " "+100+"vw "+vh+"px";
-            document.getElementsByTagName('body')[0].style.backgroundSize = transform;   
+            if (window.innerWidth < 900){mobileSize();}
+            else document.getElementsByTagName('body')[0].style.backgroundSize = transform;   
             }
+            else if (window.innerWidth < 900){mobileSize();}
             else document.getElementsByTagName('body')[0].style.backgroundSize = "1600px 750px";
         }
         bgResize();

--- a/index.html
+++ b/index.html
@@ -110,6 +110,21 @@
     <script src="js/gui.js" type="text/javascript"></script>
     <script src="js/main.js" type="text/javascript"></script>
     <script src="./js/modal.js"></script>
+    <script>
+        // JavaScript Code that resizes background image responsively
+        var zoom = Math.round(window.devicePixelRatio * 100);
+        function bgResize(){
+            if (zoom < 130){
+            var factor = 130/zoom;
+            var vh = Math.max(document.documentElement.clientHeight || 0, window.innerHeight, 750);
+            var transform = " "+100+"vw "+vh+"px";
+            document.getElementsByTagName('body')[0].style.backgroundSize = transform;   
+            }
+            else document.getElementsByTagName('body')[0].style.backgroundSize = "1600px 750px";
+        }
+        bgResize();
+        window.addEventListener("resize", bgResize);
+    </script>
 </body>
 
 </html>

--- a/styles.css
+++ b/styles.css
@@ -4,7 +4,7 @@ body {
     background-image: url('images/Background_Img.jpeg');
     background-repeat: no-repeat;
     overflow-x: hidden;
-    background-size: 100vw 100vh;
+    background-size: 1600px 750px;
 }
 
 #simple-modal {


### PR DESCRIPTION
Zoom > 130% has been left untouched, so it should work exactly like two commits ago, and as a consequence, 
one must reload the page on zooming out from 130%.  
Used JavaScript inside a script tag to resize background on window resize, which does **not** require reload.