### PR TITLE
Remove outline from the buttons and add hover effects instead Fixes #79

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -373,6 +373,30 @@ h1 {
     cursor: pointer;
 }
 
+.button-primary:focus {
+    outline: none;
+}
+
+.button-secondary:focus {
+    outline: none;
+}
+
+.button-tertiary:focus{
+    outline: none;
+}
+
+.button-primary:hover{
+    background: #020650;
+}
+
+.button-secondary:hover{
+    background: #033e5c;
+}
+
+.button-tertiary:hover{
+    background: rgb(122, 10, 10);
+}
+
 #EngineOutput {
     margin-top: 60px;
     position: absolute;


### PR DESCRIPTION
with  the ref: #79 

I removed the outline from the borders of the buttons and added hover effects instead of that which improves UI and user experience.

***before:***

![2021-01-14 (2)](https://user-images.githubusercontent.com/64387054/104594563-56b9ce00-5697-11eb-80f9-b750652b8237.png)

***after:***

![chess](https://user-images.githubusercontent.com/64387054/105463355-f1c53000-5cb5-11eb-897c-7647f57f4d34.gif)
